### PR TITLE
Cleanup: Scene structure simplification and UI polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Check our [GitHub Issues](https://github.com/crafter-station/open-screenstudio/i
 
 ---
 
+## Development Requirements
+
+| Platform | Requirement |
+|----------|-------------|
+| **macOS** | Xcode 16.2+ (macOS 15.2 SDK) |
+| **Windows** | Visual Studio 2022 with C++ tools |
+
+---
+
 ## Contributing
 
 We welcome contributions of all kinds! Whether you're fixing bugs, adding features, improving documentation, or just sharing ideas - you're helping build something great.

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -206,14 +206,18 @@ pub async fn create_project_from_recording(
         camera_position: Point { x: 0.95, y: 0.95 },
     };
 
+    // Combine screen and camera slices into a single slices list
+    let mut slices = vec![screen_slice];
+    if let Some(cam_slice) = camera_slice {
+        slices.push(cam_slice);
+    }
+
     let scene = Scene {
         id: Uuid::new_v4().to_string(),
         name: "Main".to_string(),
         scene_type: SceneType::Recording,
         session_index: 0,
-        slices: Vec::new(), // Deprecated field
-        screen_slices: vec![screen_slice],
-        camera_slices: camera_slice.map(|s| vec![s]).unwrap_or_default(),
+        slices,
         zoom_ranges: Vec::new(),
         layouts: vec![default_layout],
     };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,7 +10,6 @@ pub mod processing;
 pub mod project;
 pub mod recorder;
 pub mod utils;
-pub mod waveform;
 
 use commands::export::ExportState;
 use commands::project::AppState;
@@ -82,11 +81,8 @@ pub fn run() {
             commands::window::restore_toolbar,
             // Export commands
             commands::export::start_export,
-            commands::export::start_export_with_edits,
             commands::export::cancel_export,
             commands::export::is_exporting,
-            // Waveform commands
-            waveform::get_waveform,
         ])
         .setup(|app| {
             // Set up transparent background for toolbar window on macOS

--- a/src/index.css
+++ b/src/index.css
@@ -131,7 +131,7 @@
     align-items: flex-start;
     justify-content: center;
     background: transparent !important;
-    padding: 4px 40px;
+    padding: 4px 8px;
     box-sizing: border-box;
   }
 
@@ -144,14 +144,11 @@
     background: rgba(30, 30, 30, 0.95);
     backdrop-filter: blur(20px);
     -webkit-backdrop-filter: blur(20px);
-    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    box-shadow: none;
     white-space: nowrap;
     flex-shrink: 0;
-    /* Explicitly remove any possible border */
-    border: none !important;
-    border-width: 0 !important;
-    border-style: none !important;
-    border-color: transparent !important;
+    /* Subtle rounded border */
+    border: 1px solid rgba(255, 255, 255, 0.1) !important;
     outline: none !important;
     outline-width: 0 !important;
     -webkit-appearance: none;
@@ -163,7 +160,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 4px 2px;
+    padding: 4px 6px;
     color: rgba(255, 255, 255, 0.3);
     cursor: grab;
     flex-shrink: 0;


### PR DESCRIPTION
## Summary

This PR contains cleanup and refinement changes across documentation, backend, and frontend.

## Changes

### Documentation
- Added development requirements table to README (Xcode 16.2+ for macOS, VS 2022 for Windows)

### Backend Refactoring
- Simplified scene structure by combining `screen_slices` and `camera_slices` into a single `slices` list
- Removed unused `waveform` module and `get_waveform` command
- Removed unused `start_export_with_edits` command

### UI Polish
- Improved recording toolbar appearance with subtle rounded border
- Removed heavy box-shadow for cleaner look
- Adjusted padding for better spacing

## Testing
- [ ] Verified recording toolbar appearance
- [ ] Verified project creation still works correctly
